### PR TITLE
Composer install tweak

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,4 +9,4 @@ COPY . /usr/src/wordpress/wp-content/themes/Shanken-News-Daily/
 RUN  cp /usr/src/wordpress/wp-content/themes/Shanken-News-Daily/composer.json /usr/src/wordpress/composer.json && \
      cd /usr/src/wordpress && \
      curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/bin/ --filename=composer && \
-     composer install --no-dev --no-interaction --optimize-autoloader
+     composer install --no-dev --no-interaction --optimize-autoloader --prefer-dist

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 - Develop with docker-compose up
 - CI/CI Pipeline as follows:
 1. feature branch
-2. staging branch  PR To master.
+2. merge feature to staging branch will trigger codepipeline deploy to dev.shankennewsdaily.com
 3. Successful PR merge of master deploys code to ECS via Codepipeline
 
 TO DO:


### PR DESCRIPTION
Our [codeBuild started failing while pulling composer from source](https://console.aws.amazon.com/codesuite/codebuild/477350685613/projects/SND/build/SND%3Abf7703eb-d1bd-48be-8d7c-bdd8fb4edef4/?region=us-east-1). Looking into this makes it seem like a rate limiting issue on github's side. This PR adds `--prefer-dist` to the `composer install` command, which should hopefully work around this issue.

This should have the bonus of being faster in CI situations. From [Composer's documentation](https://getcomposer.org/doc/03-cli.md):

> This can speed up installs substantially on build servers and other use cases where you typically do not run updates of the vendors.

Opening the PR against staging so I can test on the [snd-dev pipeline](https://console.aws.amazon.com/codesuite/codepipeline/pipelines/SND-DEV/view?region=us-east-1) first. This also pulled in 9 commits that were made directly to master.